### PR TITLE
docs: mise à jour majeure du README (+ mini-tutoriel Git)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,125 @@
+# Mini‑tutoriel Git 🔧
+
+Ce guide explique pas à pas comment configurer ton identité et travailler proprement avec des branches.
+
+---
+
+## 1. Cloner le dépôt
+
+```bash
+# En local :
+git clone https://github.com/arthurmaffre/IFT2015-D1.git
+cd IFT2015-D1
+```
+
+---
+
+## 2. Configurer ton identité (une seule fois)
+
+```bash
+git config --global user.name  "Ton Nom"
+git config --global user.email "vous@example.com"
+```
+
+> Remplacez *Ton Nom* et *vous@example.com* par tes informations réelles.  
+
+---
+
+## 3. Stratégie de branches
+
+| Branche        | Rôle                                             | Qui la modifie ? |
+| -------------- | ------------------------------------------------ | --------------- |
+| **main**       | Version 100 % stable / livrable                  | *Personne directement* (merge seulement) |
+| **dev**        | Intégration continue, dernière version testée    | Tout le monde via Pull‑Request |
+| `feature/...`  | Travail sur une fonctionnalité ou un correctif   | Auteur·rice de la tâche |
+
+---
+
+## 4. Cycle de travail (exemple)
+
+```bash
+# Mettre dev à jour
+git checkout dev #va de la version ou tu travaille vers dev
+git pull origin dev #met a jour depuis le depo la derniere version de dev
+
+# Créer une branche de fonctionnalité
+git checkout -b feature/turtle-stack
+
+# … coder, tester …
+mvn test
+
+# Committer (à chaque fois que tu publie)
+git add src/main/java/lindenmayer/TurtleImpl.java #permet la mise à jour d'un fichier: git add . marche pour ajouter tout mais comme on collabore vas y fichier par fichier
+git commit -m "feat: implémentation de la pile d'états dans TurtleImpl" #m c'est le message décrit bien tout ce que tu fais pour que l'on s'y retrouve.
+
+# Pousser
+git push -u origin feature/turtle-stack #pousse le commit de ton ordi vers github
+```
+
+1. Sur GitHub : ouvrir une Pull‑Request `feature/...` → `dev`.
+2. Relecture, puis *Merge*. (si t'es pas à l'aise fait le pull request et je merge stv)
+3. Mettre dev à jour en local : (genre si je modifie et que tu veux update dev sur ton ordi depuis github)
+
+```bash
+git checkout dev
+git pull origin dev
+```
+
+---
+
+## 5. Résoudre un conflit
+
+```bash
+git pull origin dev        # sur votre branche
+# Corriger les <<<<<<< === >>>>>>> dans les fichiers
+git add <fichiers>
+git commit -m "fix: résolution de conflit"
+git push
+```
+
+---
+
+## 6. Préparer la livraison finale
+
+1. Vérifier que tout compile (`mvn test`) et que le rapport est prêt.  
+2. Ouvrir une PR `dev → main` intitulée « Release v1.0 ».  
+3. Tag :
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v1.0 -m "Version finale remise"
+git push origin v1.0
+```
+
+---
+
+## 7. Bonnes pratiques de commit
+
+- Message court au présent impératif :  
+  `feat: add Symbol.rewrite()`  
+  `fix: prevent NPE in initFromJson()`
+- Pas de fichiers générés (`*.class`, `target/`, etc.) dans les commits.
+- Une fonctionnalité = une branche = une PR.
+
+---
+
+## 8. Aide‑mémoire rapide
+
+| Action                                   | Commande |
+| ---------------------------------------- | -------- |
+| Voir l’historique graphique              | `git log --oneline --graph --decorate` |
+| Annuler le dernier commit (local)        | `git reset --soft HEAD~1` |
+| Supprimer une branche distante           | `git push origin --delete feature/...` |
+| Lister branches (locales + distantes)    | `git branch -a` |
+| Rebaser votre branche sur dev            | `git fetch origin && git rebase origin/dev` |
+
+---
+
+Avec ce tutoriel, même un•e débutant•e peut contribuer sans risque au projet.
+
+
+
 # Projet 1 : Comment dessiner un arbre
 
 ## 1. Membres de l'équipe


### PR DESCRIPTION
## Contexte
La branche dev contient maintenant un README enrichi :
- ajout d’un mini-tutoriel Git 🔧 (clonage, config, workflow de branches)
- clarification de la structure du dépôt et des tâches attribuées
- instructions de compilation / exécution Maven + exemple EPS
- tableaux et aide-mémoire pour les bonnes pratiques de commit

## Points clés
- Aucun changement dans le code source Java ; seulement de la documentation.
- Objectif : offrir un guide prêt à l’emploi pour tout nouvel·le contributeur·rice.
- Format Markdown testé sur GitHub : ✅ blocs de code, ✅ tableaux, ✅ émojis.

## À vérifier avant merge
- Orthographe / clarté du nouveau contenu
- Longueur des lignes < 120 caractères
- Liens internes (anchors) fonctionnels

Une fois validé, cela deviendra la documentation officielle sur `main`.